### PR TITLE
Add map and array extraction to ExtractNestedField

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+
 <?xml version="1.0"?>
 <!--
 
@@ -21,21 +22,30 @@
         xmlns="http://maven.apache.org/POM/4.0.0"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>com.github.jcustenborder.kafka.connect</groupId>
-        <artifactId>kafka-connect-parent</artifactId>
-        <version>3.3.1-1</version>
-    </parent>
+    <groupId>com.github.jcustenborder.kafka.connect</groupId>
     <artifactId>kafka-connect-transform-common</artifactId>
-    <version>0.1.2.1-TWM</version>
+    <version>0.1.2.7-TWM</version>
+    <packaging>jar</packaging>
     <name>kafka-connect-transform-common</name>
     <url>https://github.com/jcustenborder/kafka-connect-transform-common</url>
     <inceptionYear>2017</inceptionYear>
     <description>Common transformations for Kafka Connect.</description>
-	<properties>
-        <maven.compiler.release>21</maven.compiler.release>
-	    <slf4j.version>1.7.30</slf4j.version>
-	</properties>    
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <java.version>17</java.version>
+        <kafka.version>3.7.0</kafka.version>
+        <connect-utils.version>0.7.166</connect-utils.version>
+        <slf4j.version>1.7.30</slf4j.version>
+        <mockito.version>4.8.0</mockito.version>
+        <junit.version>5.9.1</junit.version>
+        <guava.version>31.1-jre</guava.version>
+        <confluent.hub.packaging.version>0.12.0</confluent.hub.packaging.version>
+        <surefire.version>2.22.2</surefire.version>
+        <failsafe.version>2.22.2</failsafe.version>
+    </properties>  
     <licenses>
         <license>
             <name>Apache License 2.0</name>
@@ -65,25 +75,79 @@
         <system>github</system>
         <url>https://github.com/jcustenborder/kafka-connect-transform-common/issues</url>
     </issueManagement>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-bom</artifactId>
+                <version>${mockito.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>connect-json</artifactId>
+                <version>${kafka.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>connect-api</artifactId>
+                <version>${kafka.version}</version>
+                <scope>provided</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
+        <dependency>
+            <groupId>com.github.jcustenborder.kafka.connect</groupId>
+            <artifactId>connect-utils</artifactId>
+            <version>1.1.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/lib/connect-utils-1.1.0.jar</systemPath>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jcustenborder.kafka.connect</groupId>
+            <artifactId>connect-utils-jackson</artifactId>
+            <version>1.1.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/lib/connect-utils-jackson-1.1.0.jar</systemPath>
+        </dependency>
+        <dependency>
+            <groupId>com.github.jcustenborder.kafka.connect</groupId>
+            <artifactId>connect-utils-parser</artifactId>
+            <version>1.1.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/lib/connect-utils-parser-1.1.0.jar</systemPath>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-json</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.jcustenborder.kafka.connect</groupId>
-            <artifactId>connect-utils-jackson</artifactId>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>0.9.10</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.jcustenborder.kafka.connect</groupId>
-            <artifactId>connect-utils-testing-data</artifactId>
-            <version>${connect-utils.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -106,50 +170,137 @@
             <artifactId>json-path</artifactId>
             <version>2.9.0</version>
         </dependency>
-		<dependency>
-		    <groupId>org.slf4j</groupId>
+        <dependency>
+            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>${slf4j.version}</version>
-		</dependency>        
+        </dependency>
+        <dependency>
+            <groupId>com.github.jcustenborder.kafka.connect</groupId>
+            <artifactId>connect-utils-testing</artifactId>
+            <version>1.1.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/lib/connect-utils-testing-1.1.0.jar</systemPath>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.13</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.6.0</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.puppycrawl.tools</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <version>10.21.1</version>
-                    </dependency>
-                </dependencies>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>3.5.0</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>17</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.10.1</version>
+                <configuration>
+                    <detectJavaApiLink>false</detectJavaApiLink>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.4.2</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*IT.java</exclude>
+                        <exclude>**/*IntegrationTest.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${failsafe.version}</version>
+                <executions>
+                    <execution>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>3.7.1</version>
-                <configuration>
-                    <descriptors>
-                        <descriptor>src/assembly/package.xml</descriptor>
-                    </descriptors>
-                </configuration>
                 <executions>
                     <execution>
                         <id>make-assembly</id>
@@ -157,16 +308,25 @@
                         <goals>
                             <goal>single</goal>
                         </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/assembly/package.xml</descriptor>
+                            </descriptors>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-connect-maven-plugin</artifactId>
+                <version>${confluent.hub.packaging.version}</version>
                 <executions>
                     <execution>
                         <id>hub</id>
                         <phase>none</phase>
+                        <goals>
+                            <goal>kafka-connect</goal>
+                        </goals>
                     </execution>
                 </executions>
                 <configuration>
@@ -187,4 +347,10 @@
             </plugin>
         </plugins>
     </build>
+    <repositories>
+        <repository>
+            <id>confluent</id>
+            <url>https://packages.confluent.io/maven/</url>
+        </repository>
+    </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <version>3.3.1-1</version>
     </parent>
     <artifactId>kafka-connect-transform-common</artifactId>
-    <version>0.1.2.0-TWM</version>
+    <version>0.1.2.1-TWM</version>
     <name>kafka-connect-transform-common</name>
     <url>https://github.com/jcustenborder/kafka-connect-transform-common</url>
     <inceptionYear>2017</inceptionYear>

--- a/src/assembly/package.xml
+++ b/src/assembly/package.xml
@@ -1,6 +1,6 @@
-<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
     <id>package</id>
     <formats>
         <format>dir</format>
@@ -11,7 +11,7 @@
         <dependencySet>
             <outputDirectory>lib</outputDirectory>
             <useProjectArtifact>true</useProjectArtifact>
-            <scope>runtime</scope>
+            <useTransitiveFiltering>false</useTransitiveFiltering>
             <excludes>
                 <exclude>org.apache.kafka:*</exclude>
             </excludes>
@@ -19,24 +19,25 @@
     </dependencySets>
     <fileSets>
         <fileSet>
-            <directory>${project.basedir}/docs</directory>
-            <outputDirectory>doc</outputDirectory>
+            <directory>${project.basedir}/lib</directory>
+            <outputDirectory>lib</outputDirectory>
             <includes>
-                <include>**/*</include>
-            </includes>
-        </fileSet>
-        <fileSet>
-            <directory>${project.basedir}/config</directory>
-            <outputDirectory>etc</outputDirectory>
-            <includes>
-                <include>**/*</include>
+                <include>*.jar</include>
             </includes>
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/src/main/resources</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory/>
             <includes>
                 <include>manifest.json</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}</directory>
+            <outputDirectory>doc</outputDirectory>
+            <includes>
+                <include>README*</include>
+                <include>LICENSE*</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/src/assembly/package.xml
+++ b/src/assembly/package.xml
@@ -9,7 +9,7 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <dependencySets>
         <dependencySet>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory>lib</outputDirectory>
             <useProjectArtifact>true</useProjectArtifact>
             <scope>runtime</scope>
             <excludes>
@@ -17,4 +17,27 @@
             </excludes>
         </dependencySet>
     </dependencySets>
+    <fileSets>
+        <fileSet>
+            <directory>${project.basedir}/docs</directory>
+            <outputDirectory>doc</outputDirectory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/config</directory>
+            <outputDirectory>etc</outputDirectory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/src/main/resources</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>manifest.json</include>
+            </includes>
+        </fileSet>
+    </fileSets>
 </assembly>

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "kafka-connect-transform-common",
-  "version": "0.1.2.1-TWM",
+  "version": "0.1.2.4-TWM",
   "title": "Kafka Connect Common Transformations",
   "description": "Common transformations for Kafka Connect.",
   "owner": {
@@ -18,7 +18,7 @@
   "features": {
     "confluent_control_center_integration": true
   },
-  "documentation_url": "https://jcustenborder.github.io/kafka-connect-documentation/",
+  "logo": "",
   "component_types": [
     "transform"
   ]

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -1,0 +1,25 @@
+{
+  "name": "kafka-connect-transform-common",
+  "version": "0.1.2.1-TWM",
+  "title": "Kafka Connect Common Transformations",
+  "description": "Common transformations for Kafka Connect.",
+  "owner": {
+    "username": "jcustenborder",
+    "name": "Jeremy Custenborder"
+  },
+  "support": {
+    "summary": "Support provided through community involvement.",
+    "url": "https://github.com/jcustenborder/kafka-connect-transform-common/issues"
+  },
+  "tags": [
+    "Common",
+    "Transformation"
+  ],
+  "features": {
+    "confluent_control_center_integration": true
+  },
+  "documentation_url": "https://jcustenborder.github.io/kafka-connect-documentation/",
+  "component_types": [
+    "transform"
+  ]
+}

--- a/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractNestedFieldTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractNestedFieldTest.java
@@ -20,11 +20,12 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.apache.kafka.connect.transforms.Transformation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.github.jcustenborder.kafka.connect.utils.AssertSchema.assertSchema;
 import static com.github.jcustenborder.kafka.connect.utils.AssertStruct.assertStruct;
@@ -33,11 +34,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ExtractNestedFieldTest {
-  private Transformation<SinkRecord> transformation;
+  private ExtractNestedField.Value<SinkRecord> transformation;
 
   @BeforeEach
   public void before() {
-    this.transformation = new ExtractNestedField.Value();
+    this.transformation = new ExtractNestedField.Value<>();
   }
 
   @Test
@@ -378,6 +379,368 @@ public class ExtractNestedFieldTest {
     assertNotNull(transformedRecord, "transformedRecord should not be null.");
     assertSchema(expectedSchema, transformedRecord.valueSchema());
     assertStruct(expectedStruct, (Struct) transformedRecord.value());
+  }
+
+  @Test
+  public void testMapExtraction() {
+    this.transformation.configure(
+        ImmutableMap.of(
+            ExtractNestedFieldConfig.INNER_FIELD_NAME_CONF, "data",
+            ExtractNestedFieldConfig.OUTER_FIELD_NAME_CONF, "after",
+            ExtractNestedFieldConfig.OUTPUT_FIELD_NAME_CONF, "data"
+        )
+    );
+
+    // Create a schema with a MAP field
+    final Schema dataSchema = SchemaBuilder.struct()
+        .name("Data")
+        .field("key", Schema.STRING_SCHEMA)
+        .field("value", Schema.STRING_SCHEMA)
+        .build();
+    
+    final Schema inputSchema = SchemaBuilder.struct()
+        .field("id", Schema.INT32_SCHEMA)
+        .field("after", SchemaBuilder.map(Schema.STRING_SCHEMA, dataSchema).build())
+        .build();
+    
+    final Schema expectedSchema = SchemaBuilder.struct()
+        .field("id", Schema.INT32_SCHEMA)
+        .field("after", SchemaBuilder.map(Schema.STRING_SCHEMA, dataSchema).build())
+        .field("data", dataSchema)
+        .build();
+
+    final Struct dataStruct = new Struct(dataSchema)
+        .put("key", "testKey")
+        .put("value", "testValue");
+    
+    final Struct inputStruct = new Struct(inputSchema)
+        .put("id", 123)
+        .put("after", ImmutableMap.of("data", dataStruct, "other", new Struct(dataSchema).put("key", "otherKey").put("value", "otherValue")));
+
+    final Struct expectedStruct = new Struct(expectedSchema)
+        .put("id", 123)
+        .put("after", ImmutableMap.of("data", dataStruct, "other", new Struct(dataSchema).put("key", "otherKey").put("value", "otherValue")))
+        .put("data", dataStruct);
+
+    final SinkRecord inputRecord = new SinkRecord(
+        "topic",
+        1,
+        null,
+        null,
+        inputSchema,
+        inputStruct,
+        1L
+    );
+
+    final SinkRecord transformedRecord = this.transformation.apply(inputRecord);
+    assertNotNull(transformedRecord, "transformedRecord should not be null.");
+    assertSchema(expectedSchema, transformedRecord.valueSchema());
+    assertStruct(expectedStruct, (Struct) transformedRecord.value());
+  }
+
+  @Test
+  public void testMapExtractionMissingKey() {
+    this.transformation.configure(
+        ImmutableMap.of(
+            ExtractNestedFieldConfig.INNER_FIELD_NAME_CONF, "missing",
+            ExtractNestedFieldConfig.OUTER_FIELD_NAME_CONF, "after",
+            ExtractNestedFieldConfig.OUTPUT_FIELD_NAME_CONF, "extracted"
+        )
+    );
+
+    final Schema dataSchema = SchemaBuilder.struct()
+        .field("value", Schema.STRING_SCHEMA)
+        .build();
+    
+    final Schema inputSchema = SchemaBuilder.struct()
+        .field("after", SchemaBuilder.map(Schema.STRING_SCHEMA, dataSchema).build())
+        .build();
+
+    final Struct dataStruct = new Struct(dataSchema)
+        .put("value", "testValue");
+    
+    final Struct inputStruct = new Struct(inputSchema)
+        .put("after", ImmutableMap.of("data", dataStruct));
+
+    final SinkRecord inputRecord = new SinkRecord(
+        "topic",
+        1,
+        null,
+        null,
+        inputSchema,
+        inputStruct,
+        1L
+    );
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      this.transformation.apply(inputRecord);
+    });
+    assertEquals("Cannot find key 'missing' in map field 'after'", exception.getMessage());
+  }
+
+  @Test
+  public void testSchemalessMapExtraction() {
+    this.transformation.configure(
+        ImmutableMap.of(
+            ExtractNestedFieldConfig.INNER_FIELD_NAME_CONF, "data",
+            ExtractNestedFieldConfig.OUTER_FIELD_NAME_CONF, "after",
+            ExtractNestedFieldConfig.OUTPUT_FIELD_NAME_CONF, "data"
+        )
+    );
+
+    // Simulate schemaless JSON (no schema, Map value)
+    final Map<Object, Object> nestedData = new HashMap<>();
+    nestedData.put("key", "testKey");
+    nestedData.put("value", "testValue");
+    nestedData.put("timestamp", "2026-01-06T17:45:12Z");
+
+    final Map<Object, Object> afterMap = new HashMap<>();
+    afterMap.put("data", nestedData);
+    afterMap.put("other", "otherValue");
+
+    final Map<Object, Object> inputValue = new HashMap<>();
+    inputValue.put("after", afterMap);
+    inputValue.put("updated", "123456789");
+
+    final SinkRecord inputRecord = new SinkRecord(
+        "topic",
+        1,
+        null,
+        null,
+        null,  // No schema
+        inputValue,
+        1L
+    );
+
+    final SinkRecord transformedRecord = this.transformation.apply(inputRecord);
+    assertNotNull(transformedRecord, "transformedRecord should not be null.");
+    
+    final Map<?, ?> result = (Map<?, ?>) transformedRecord.value();
+    assertEquals("123456789", result.get("updated"), "Original field should be preserved");
+    assertEquals(afterMap, result.get("after"), "Original after field should be preserved");
+    assertEquals(nestedData, result.get("data"), "Extracted data field should be present");
+    assertEquals("testKey", ((Map<?, ?>) result.get("data")).get("key"));
+  }
+
+  @Test
+  public void testSchemalessMapExtractionChain() {
+    // Simulate the user's actual use case: chaining multiple extractions
+    final ExtractNestedField.Value<SinkRecord> transform1 = new ExtractNestedField.Value<>();
+    final ExtractNestedField.Value<SinkRecord> transform2 = new ExtractNestedField.Value<>();
+    final ExtractNestedField.Value<SinkRecord> transform3 = new ExtractNestedField.Value<>();
+    
+    transform1.configure(
+        ImmutableMap.of(
+            ExtractNestedFieldConfig.INNER_FIELD_NAME_CONF, "data",
+            ExtractNestedFieldConfig.OUTER_FIELD_NAME_CONF, "after",
+            ExtractNestedFieldConfig.OUTPUT_FIELD_NAME_CONF, "data"
+        )
+    );
+    
+    transform2.configure(
+        ImmutableMap.of(
+            ExtractNestedFieldConfig.INNER_FIELD_NAME_CONF, "value",
+            ExtractNestedFieldConfig.OUTER_FIELD_NAME_CONF, "data",
+            ExtractNestedFieldConfig.OUTPUT_FIELD_NAME_CONF, "value"
+        )
+    );
+    
+    transform3.configure(
+        ImmutableMap.of(
+            ExtractNestedFieldConfig.INNER_FIELD_NAME_CONF, "price",
+            ExtractNestedFieldConfig.OUTER_FIELD_NAME_CONF, "value",
+            ExtractNestedFieldConfig.OUTPUT_FIELD_NAME_CONF, "price"
+        )
+    );
+
+    // Build nested structure similar to user's real data
+    final Map<Object, Object> priceData = new HashMap<>();
+    priceData.put("StoreKey", 916);
+    priceData.put("ItemPositionKey", "1000016750-SINGLE");
+    priceData.put("RetailPrice", 199.99);
+
+    final Map<Object, Object> price = new HashMap<>();
+    price.put("data", priceData);
+
+    final Map<Object, Object> value = new HashMap<>();
+    value.put("price", price);
+
+    final Map<Object, Object> data = new HashMap<>();
+    data.put("value", value);
+    data.put("key", "1000016750-916-SINGLE");
+
+    final Map<Object, Object> after = new HashMap<>();
+    after.put("data", data);
+
+    final Map<Object, Object> inputValue = new HashMap<>();
+    inputValue.put("after", after);
+    inputValue.put("updated", "1767721512577677111.0000000000");
+
+    SinkRecord record = new SinkRecord(
+        "topic",
+        1,
+        null,
+        null,
+        null,
+        inputValue,
+        1L
+    );
+
+    // Apply transform chain
+    record = transform1.apply(record);
+    assertNotNull(((Map<?, ?>) record.value()).get("data"), "data should be extracted");
+    
+    record = transform2.apply(record);
+    assertNotNull(((Map<?, ?>) record.value()).get("value"), "value should be extracted");
+    
+    record = transform3.apply(record);
+    final Map<?, ?> result = (Map<?, ?>) record.value();
+    assertNotNull(result.get("price"), "price should be extracted");
+    assertEquals(price, result.get("price"));
+    
+    // Verify original fields are preserved
+    assertEquals("1767721512577677111.0000000000", result.get("updated"));
+    assertEquals(after, result.get("after"));
+  }
+
+  @Test
+  public void testSchemalessMapExtractionMissingKey() {
+    this.transformation.configure(
+        ImmutableMap.of(
+            ExtractNestedFieldConfig.INNER_FIELD_NAME_CONF, "missing",
+            ExtractNestedFieldConfig.OUTER_FIELD_NAME_CONF, "after",
+            ExtractNestedFieldConfig.OUTPUT_FIELD_NAME_CONF, "extracted"
+        )
+    );
+
+    final Map<Object, Object> data = new HashMap<>();
+    data.put("value", "testValue");
+
+    final Map<Object, Object> after = new HashMap<>();
+    after.put("data", data);
+
+    final Map<Object, Object> inputValue = new HashMap<>();
+    inputValue.put("after", after);
+
+    final SinkRecord inputRecord = new SinkRecord(
+        "topic",
+        1,
+        null,
+        null,
+        null,
+        inputValue,
+        1L
+    );
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      this.transformation.apply(inputRecord);
+    });
+    assertEquals("Cannot find key 'missing' in nested map field 'after'", exception.getMessage());
+  }
+
+  @Test
+  public void testSchemalessMapExtractionNullOuterField() {
+    this.transformation.configure(
+        ImmutableMap.of(
+            ExtractNestedFieldConfig.INNER_FIELD_NAME_CONF, "data",
+            ExtractNestedFieldConfig.OUTER_FIELD_NAME_CONF, "missing",
+            ExtractNestedFieldConfig.OUTPUT_FIELD_NAME_CONF, "extracted"
+        )
+    );
+
+    final Map<Object, Object> inputValue = new HashMap<>();
+    inputValue.put("after", new HashMap<>());
+
+    final SinkRecord inputRecord = new SinkRecord(
+        "topic",
+        1,
+        null,
+        null,
+        null,
+        inputValue,
+        1L
+    );
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      this.transformation.apply(inputRecord);
+    });
+    assertEquals("Outer field 'missing' not found or is null", exception.getMessage());
+  }
+
+  @Test
+  public void testSchemalessArrayExtraction() {
+    this.transformation.configure(
+        ImmutableMap.of(
+            ExtractNestedFieldConfig.INNER_FIELD_NAME_CONF, "0",
+            ExtractNestedFieldConfig.OUTER_FIELD_NAME_CONF, "ClusterPrice",
+            ExtractNestedFieldConfig.OUTPUT_FIELD_NAME_CONF, "ClusterPriceFirst"
+        )
+    );
+
+    final Map<Object, Object> clusterPrice1 = new HashMap<>();
+    clusterPrice1.put("ClusterKey", 17);
+    clusterPrice1.put("ClusterPrice", 164.99);
+    clusterPrice1.put("ItemPositionKey", "1000016750-SINGLE");
+
+    final Map<Object, Object> clusterPrice2 = new HashMap<>();
+    clusterPrice2.put("ClusterKey", 17);
+    clusterPrice2.put("ClusterPrice", 199.99);
+    clusterPrice2.put("ItemPositionKey", "1000016750-SINGLE");
+
+    final Map<Object, Object> inputValue = new HashMap<>();
+    inputValue.put("ClusterPrice", Arrays.asList(clusterPrice1, clusterPrice2));
+    inputValue.put("StoreKey", 916);
+
+    final SinkRecord inputRecord = new SinkRecord(
+        "topic",
+        1,
+        null,
+        null,
+        null,
+        inputValue,
+        1L
+    );
+
+    final SinkRecord transformedRecord = this.transformation.apply(inputRecord);
+    assertNotNull(transformedRecord, "transformedRecord should not be null.");
+    
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> result = (Map<String, Object>) transformedRecord.value();
+    assertEquals(916, result.get("StoreKey"));
+    
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> extractedClusterPrice = (Map<String, Object>) result.get("ClusterPriceFirst");
+    assertEquals(17, extractedClusterPrice.get("ClusterKey"));
+    assertEquals(164.99, extractedClusterPrice.get("ClusterPrice"));
+  }
+
+  @Test
+  public void testSchemalessArrayExtractionOutOfBounds() {
+    this.transformation.configure(
+        ImmutableMap.of(
+            ExtractNestedFieldConfig.INNER_FIELD_NAME_CONF, "5",
+            ExtractNestedFieldConfig.OUTER_FIELD_NAME_CONF, "items",
+            ExtractNestedFieldConfig.OUTPUT_FIELD_NAME_CONF, "item"
+        )
+    );
+
+    final Map<Object, Object> inputValue = new HashMap<>();
+    inputValue.put("items", Arrays.asList("item1", "item2"));
+
+    final SinkRecord inputRecord = new SinkRecord(
+        "topic",
+        1,
+        null,
+        null,
+        null,
+        inputValue,
+        1L
+    );
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+      this.transformation.apply(inputRecord);
+    });
+    assertEquals("Cannot access index 5 in array field 'items' (size: 2)", exception.getMessage());
   }
 
 }

--- a/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractNestedFieldTest.java
+++ b/src/test/java/com/github/jcustenborder/kafka/connect/transform/common/ExtractNestedFieldTest.java
@@ -16,12 +16,12 @@
 package com.github.jcustenborder.kafka.connect.transform.common;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.transforms.Transformation;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -32,9 +32,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public abstract class ExtractNestedFieldTest extends TransformationTest {
-  protected ExtractNestedFieldTest(boolean isKey) {
-    super(isKey);
+public class ExtractNestedFieldTest {
+  private Transformation<SinkRecord> transformation;
+
+  @BeforeEach
+  public void before() {
+    this.transformation = new ExtractNestedField.Value();
   }
 
   @Test
@@ -375,18 +378,6 @@ public abstract class ExtractNestedFieldTest extends TransformationTest {
     assertNotNull(transformedRecord, "transformedRecord should not be null.");
     assertSchema(expectedSchema, transformedRecord.valueSchema());
     assertStruct(expectedStruct, (Struct) transformedRecord.value());
-  }
-
-
-  public static class ValueTest<R extends ConnectRecord<R>> extends ExtractNestedFieldTest {
-    protected ValueTest() {
-      super(false);
-    }
-
-    @Override
-    protected Transformation<SinkRecord> create() {
-      return new ExtractNestedField.Value();
-    }
   }
 
 }


### PR DESCRIPTION
Enhanced ExtractNestedField to support extraction from nested maps and arrays for both schemaless and schema-based records. Updated tests to cover new extraction scenarios, including error handling for missing keys and out-of-bounds array indices. Also updated Maven configuration, assembly descriptor, and added a manifest.json for packaging.